### PR TITLE
Fix MercadoPago test payment processing and checkout retry logic

### DIFF
--- a/app/api/mercadopago/webhook/route.ts
+++ b/app/api/mercadopago/webhook/route.ts
@@ -49,10 +49,15 @@ export async function POST(request: NextRequest) {
     // Get the payment details from MercadoPago
     const paymentId = body.data.id
     
-    // Handle test webhook from MercadoPago dashboard
-    if (paymentId === '123456' || body.live_mode === false) {
-      console.log('[MercadoPago Webhook] Test webhook received, responding with success')
+    // Handle MercadoPago dashboard test webhook (with dummy payment ID)
+    if (paymentId === '123456') {
+      console.log('[MercadoPago Webhook] MercadoPago dashboard test webhook received, responding with success')
       return NextResponse.json({ received: true, test: true })
+    }
+    
+    // Log test mode status but continue processing
+    if (body.live_mode === false) {
+      console.log('[MercadoPago Webhook] Processing test mode payment:', paymentId)
     }
     
     const payment = getPayment()

--- a/app/dashboard/checkout/success/page.tsx
+++ b/app/dashboard/checkout/success/page.tsx
@@ -28,12 +28,12 @@ export default function CheckoutSuccessPage() {
     }
   }, [user, sessionId, paymentId, status])
 
-  const checkPurchase = async () => {
+  const checkPurchase = async (currentRetryCount = retryCount) => {
     try {
-      console.log('[CheckoutSuccess] Starting purchase check, attempt:', retryCount + 1)
+      console.log('[CheckoutSuccess] Starting purchase check, attempt:', currentRetryCount + 1)
       
       // Wait a moment for webhook to process (longer on retries)
-      const waitTime = retryCount === 0 ? 2000 : 3000
+      const waitTime = currentRetryCount === 0 ? 2000 : 3000
       await new Promise(resolve => setTimeout(resolve, waitTime))
 
       // Get auth headers
@@ -56,11 +56,12 @@ export default function CheckoutSuccessPage() {
         if (data.purchase) {
           setPurchase(data.purchase)
           setLoading(false)
-        } else if (retryCount < 3) {
+        } else if (currentRetryCount < 3) {
           // No purchase found yet, retry up to 3 times
           console.log('[CheckoutSuccess] No purchase found, retrying...')
-          setRetryCount(prev => prev + 1)
-          setTimeout(() => checkPurchase(), 2000)
+          const newRetryCount = currentRetryCount + 1
+          setRetryCount(newRetryCount)
+          setTimeout(() => checkPurchase(newRetryCount), 2000)
         } else {
           // Max retries reached
           console.error('[CheckoutSuccess] Purchase not found after retries')


### PR DESCRIPTION
## Summary
- Fixed webhook handler to process test mode payments instead of skipping them
- Fixed infinite retry loop in checkout success page by properly managing retry counter state
- Test payments now create proper database records during development/testing

## Problem
The MercadoPago webhook was configured to skip all test mode payments (`live_mode: false`), causing test payments to succeed on MercadoPago's side but never be recorded in the database. This left users stuck on the checkout success page in an infinite retry loop.

## Solution
- Modified webhook to only skip MercadoPago dashboard test webhooks (payment ID "123456") while processing actual test payments
- Fixed checkout success page retry logic to prevent infinite loops by properly passing retry count as parameter

## Test plan
- [ ] Test MercadoPago payment flow with test credentials
- [ ] Verify webhook processes test payments and creates database records
- [ ] Confirm checkout success page displays purchase details after payment
- [ ] Ensure retry logic stops after 3 attempts if no purchase found

🤖 Generated with [Claude Code](https://claude.ai/code)